### PR TITLE
docs(reference): add Menu and Command IDs reference

### DIFF
--- a/src/content/docs/menu-ids.mdx
+++ b/src/content/docs/menu-ids.mdx
@@ -1,0 +1,599 @@
+---
+title: Menu and Command Group IDs
+description: Complete reference of Visual Studio menu, toolbar, and command group identifiers.
+category: reference
+order: 8
+---
+
+This is the complete reference of all menu IDs (`IDM_VS_*`) and command group IDs (`IDG_VS_*`) defined in the Visual Studio SDK. All IDs use the `guidSHLMainMenu` GUID: `{D309F791-903F-11D0-9EFC-00A0C911004F}`
+
+---
+
+## Main Menu Bar
+
+### Top-Level Menus
+
+| ID | Hex | Description |
+|----|-----|-------------|
+| `IDM_VS_MENU_FILE` | 0x0080 | File menu |
+| `IDM_VS_MENU_EDIT` | 0x0081 | Edit menu |
+| `IDM_VS_MENU_VIEW` | 0x0082 | View menu |
+| `IDM_VS_MENU_PROJECT` | 0x0083 | Project menu |
+| `IDM_VS_MENU_BUILD` | 0x008C | Build menu |
+| `IDM_VS_MENU_DEBUG` | 0x0089 | Debug menu |
+| `IDM_VS_MENU_FORMAT` | 0x008A | Format menu |
+| `IDM_VS_MENU_TOOLS` | 0x0085 | Tools menu |
+| `IDM_VS_MENU_EXTENSIONS` | 0x0091 | Extensions menu |
+| `IDM_VS_MENU_WINDOW` | 0x0086 | Window menu |
+| `IDM_VS_MENU_HELP` | 0x0088 | Help menu |
+| `IDM_VS_MENU_REFACTORING` | 0x008F | Refactoring menu |
+| `IDM_VS_MENU_COMMUNITY` | 0x0090 | Community menu |
+| `IDM_VS_MENU_ADDINS` | 0x0087 | Add-ins menu (legacy) |
+| `IDM_VS_MENU_ALLMACROS` | 0x008B | All Macros menu |
+| `IDM_VS_MENU_CONTEXTMENUS` | 0x008D | Context Menus |
+
+### Main Menu Groups
+
+| ID | Hex | Description |
+|----|-----|-------------|
+| `IDG_VS_MM_FILEEDITVIEW` | 0x0101 | File/Edit/View menus location |
+| `IDG_VS_MM_PROJECT` | 0x0102 | Project menu location |
+| `IDG_VS_MM_BUILDDEBUGRUN` | 0x0103 | Build/Debug/Run menus location |
+| `IDG_VS_MM_TOOLSADDINS` | 0x0104 | Tools/Add-ins menu location |
+| `IDG_VS_MM_WINDOWHELP` | 0x0105 | Window/Help menus location |
+| `IDG_VS_MM_FULLSCREENBAR` | 0x0106 | Full screen group |
+| `IDG_VS_MM_REFACTORING` | 0x0107 | Refactoring menu location |
+| `IDG_VS_MM_TOOLS` | 0x0109 | Tools menu location |
+| `IDG_VS_MM_MACROS` | 0x010A | Macros menu location |
+| `IDG_VS_MENU_CONTEXTMENUS` | 0x008E | Context menus group |
+
+---
+
+## File Menu Groups
+
+| ID | Hex | Description |
+|----|-----|-------------|
+| `IDG_VS_FILE_FILE` | 0x0110 | File operations |
+| `IDG_VS_FILE_NEW_CASCADE` | 0x0119 | New submenu |
+| `IDG_VS_FILE_NEWP_CASCADE` | 0x0712 | New Project cascade |
+| `IDG_VS_FILE_NEWF_CASCADE` | 0x0714 | New File cascade |
+| `IDG_VS_FILE_NEW_PROJ_CSCD` | 0x010E | New Project cascade |
+| `IDG_VS_FILE_NEWREPO_CASCADE` | 0x0713 | New Repository cascade |
+| `IDG_VS_FILE_ITEM` | 0x010F | File item operations |
+| `IDG_VS_FILE_ADD` | 0x0111 | Add operations |
+| `IDG_VS_FILE_ADD_PROJECT_NEW` | 0x011C | Add new project |
+| `IDG_VS_FILE_ADD_PROJECT_EXI` | 0x011D | Add existing project |
+| `IDG_VS_FILE_OPENP_CASCADE` | 0x011A | Open Project cascade |
+| `IDG_VS_FILE_OPENF_CASCADE` | 0x011B | Open File cascade |
+| `IDG_VS_FILE_OPENFOLDER_CASCADE` | 0x0715 | Open Folder cascade |
+| `IDG_VS_FILE_OPENREPO_CASCADE` | 0x0716 | Open Repository cascade |
+| `IDG_VS_FILE_OPENSCC_CASCADE` | 0x0127 | Open Source Control cascade |
+| `IDG_VS_FILE_SAVE` | 0x0112 | Save operations |
+| `IDG_VS_FILE_RENAME` | 0x0113 | Rename operations |
+| `IDG_VS_FILE_PRINT` | 0x0114 | Print operations |
+| `IDG_VS_FILE_MRU` | 0x0115 | Most Recently Used |
+| `IDG_VS_FILE_FMRU_CASCADE` | 0x011E | File MRU cascade |
+| `IDG_VS_FILE_PMRU_CASCADE` | 0x011F | Project MRU cascade |
+| `IDG_VS_FILE_DELETE` | 0x0117 | Delete operations |
+| `IDG_VS_FILE_SOLUTION` | 0x0118 | Solution operations |
+| `IDG_VS_FILE_BROWSER` | 0x0120 | Browser operations |
+| `IDG_VS_FILE_MOVE` | 0x0121 | Move operations |
+| `IDG_VS_FILE_MOVE_CASCADE` | 0x0122 | Move cascade |
+| `IDG_VS_FILE_MOVE_PICKER` | 0x0123 | Move picker |
+| `IDG_VS_FILE_MISC` | 0x0124 | Miscellaneous |
+| `IDG_VS_FILE_MISC_CASCADE` | 0x0125 | Misc cascade |
+| `IDG_VS_FILE_MAKE_EXE` | 0x0126 | Make EXE |
+| `IDG_VS_FILE_EXIT` | 0x0116 | Exit |
+| `IDG_VS_FILE_ACCOUNTSETTINGS` | 0x0711 | Account settings |
+
+---
+
+## Edit Menu Groups
+
+| ID | Hex | Description |
+|----|-----|-------------|
+| `IDG_VS_EDIT_UNDOREDO` | 0x0129 | Undo/Redo |
+| `IDG_VS_EDIT_CUTCOPY` | 0x012A | Cut/Copy/Paste |
+| `IDG_VS_EDIT_PASTE` | 0x012F | Paste operations |
+| `IDG_VS_EDIT_SELECT` | 0x012B | Selection |
+| `IDG_VS_EDIT_FIND` | 0x012C | Find operations |
+| `IDG_VS_EDIT_GOTO` | 0x012D | Go To operations |
+| `IDG_VS_EDIT_OBJECTS` | 0x0128 | Object operations |
+| `IDG_VS_EDIT_OLEVERBS` | 0x01A8 | OLE verbs |
+| `IDG_VS_EDIT_COMMANDWELL` | 0x012E | Command well |
+
+---
+
+## View Menu Groups
+
+| ID | Hex | Description |
+|----|-----|-------------|
+| `IDG_VS_VIEW_BROWSER` | 0x0130 | Browser |
+| `IDG_VS_VIEW_PROPPAGES` | 0x0131 | Property pages |
+| `IDG_VS_VIEW_TOOLBARS` | 0x0132 | Toolbars submenu |
+| `IDG_VS_VIEW_FORMCODE` | 0x0133 | Form/Code toggle |
+| `IDG_VS_VIEW_DEFINEVIEWS` | 0x0134 | Define views |
+| `IDG_VS_VIEW_WINDOWS` | 0x0135 | Windows |
+| `IDG_VS_VIEW_ARCH_WINDOWS` | 0x0720 | Architecture windows |
+| `IDG_VS_VIEW_ORG_WINDOWS` | 0x0721 | Organization windows |
+| `IDG_VS_VIEW_CODEBROWSENAV_WINDOWS` | 0x0722 | Code browse/nav windows |
+| `IDG_VS_VIEW_DEV_WINDOWS` | 0x0723 | Developer windows |
+| `IDG_VS_VIEW_REFRESH` | 0x0136 | Refresh |
+| `IDG_VS_VIEW_NAVIGATE` | 0x0137 | Navigate |
+| `IDG_VS_VIEW_SYMBOLNAVIGATE` | 0x0138 | Symbol navigate |
+| `IDG_VS_VIEW_SMALLNAVIGATE` | 0x0139 | Small navigate |
+| `IDG_VS_VIEW_OBJBRWSR` | 0x013A | Object Browser |
+| `IDG_VS_VIEW_LINKS` | 0x013B | Links |
+| `IDG_VS_VIEW_COMMANDWELL` | 0x013C | Command well |
+| `IDG_VS_WNDO_FINDRESULTS` | 0x0724 | Find Results windows |
+
+---
+
+## Project Menu Groups
+
+| ID | Hex | Description |
+|----|-----|-------------|
+| `IDG_VS_PROJ_ADD` | 0x0140 | Add items |
+| `IDG_VS_PROJ_ADDCODE` | 0x0145 | Add code items |
+| `IDG_VS_PROJ_MISCADD` | 0x014C | Misc add items |
+| `IDG_VS_PROJ_ADDREMOVE` | 0x0147 | Add/Remove |
+| `IDG_VS_PROJ_FOLDER` | 0x0143 | Folder operations |
+| `IDG_VS_PROJ_OPTIONS` | 0x0141 | Options |
+| `IDG_VS_PROJ_SETTINGS` | 0x014D | Settings |
+| `IDG_VS_PROJ_REFERENCE` | 0x0142 | References |
+| `IDG_VS_PROJ_PROJECT` | 0x0146 | Project operations |
+| `IDG_VS_PROJ_UNLOADRELOAD` | 0x0144 | Unload/Reload |
+| `IDG_VS_PROJ_WEB1` | 0x0148 | Web 1 |
+| `IDG_VS_PROJ_WEB2` | 0x0149 | Web 2 |
+| `IDG_VS_PROJ_TOOLBAR1` | 0x014A | Toolbar 1 |
+| `IDG_VS_PROJ_TOOLBAR2` | 0x014B | Toolbar 2 |
+| `IDG_VS_PROJ_ADMIN` | 0x014E | Admin |
+
+---
+
+## Debug Menu Groups
+
+| ID | Hex | Description |
+|----|-----|-------------|
+| `IDG_VS_RUN_START` | 0x0150 | Start debugging |
+| `IDG_VS_DBG_STEP` | 0x0151 | Step commands |
+| `IDG_VS_DBG_WATCH` | 0x0152 | Watch operations |
+| `IDG_VS_DBG_BRKPTS` | 0x0153 | Breakpoints |
+| `IDG_VS_DBG_STATEMENT` | 0x0154 | Statement |
+| `IDG_VS_DBG_ATTACH` | 0x0155 | Attach to process |
+| `IDG_VS_DBG_TBBRKPTS` | 0x0156 | Toolbar breakpoints |
+| `IDG_VS_DBG_DBGWINDOWS` | 0x0157 | Debug windows |
+| `IDG_VS_DEBUG_DISPLAYRADIX` | 0x0185 | Display radix |
+
+---
+
+## Tools Menu Groups
+
+| ID | Hex | Description |
+|----|-----|-------------|
+| `IDG_VS_TOOLS_EXT_CUST` | 0x0158 | External customization |
+| `IDG_VS_TOOLS_EXT_TOOLS` | 0x0159 | External tools |
+| `IDG_VS_TOOLS_OPTIONS` | 0x015A | Options |
+| `IDG_VS_TOOLS_OTHER2` | 0x015B | Other tools |
+| `IDG_VS_TOOLS_OBJSUBSET` | 0x015C | Object subset |
+| `IDG_VS_TOOLS_EXTENSIBILITY` | 0x015F | Extensibility |
+| `IDG_VS_ADDIN_BUILTIN` | 0x015D | Built-in add-ins |
+| `IDG_VS_ADDIN_MANAGER` | 0x015E | Add-in manager |
+
+---
+
+## Extensions Menu Groups
+
+| ID | Hex | Description |
+|----|-----|-------------|
+| `IDG_VS_EXTENSIONS` | 0x6000 | Extensions |
+| `IDG_VS_EXTENSIONS_REPARENT` | 0x6001 | Extensions reparent |
+
+---
+
+## Window Menu Groups
+
+| ID | Hex | Description |
+|----|-----|-------------|
+| `IDG_VS_WINDOW_NEW` | 0x0160 | New window |
+| `IDG_VS_WINDOW_ARRANGE` | 0x0161 | Arrange windows |
+| `IDG_VS_WINDOW_LIST` | 0x0162 | Window list |
+| `IDG_VS_WINDOW_NAVIGATION` | 0x0163 | Navigation |
+| `IDG_VS_WINDOW_LAYOUT` | 0x0164 | Window layout |
+| `IDG_VS_WINDOW_LAYOUT_LIST` | 0x0165 | Layout list |
+| `IDG_VS_WINDOW_TABORIENTATION` | 0x0166 | Tab orientation |
+| `IDG_VS_WINDOW_SPLIT` | 0x0167 | Split tab |
+
+---
+
+## Help Menu Groups
+
+| ID | Hex | Description |
+|----|-----|-------------|
+| `IDG_VS_HELP_SUPPORT` | 0x016A | Support |
+| `IDG_VS_HELP_ABOUT` | 0x016B | About |
+| `IDG_VS_HELP_ACCESSIBILITY` | 0x016D | Accessibility |
+
+---
+
+## Toolbars
+
+### Standard Toolbars
+
+| ID | Hex | Description |
+|----|-----|-------------|
+| `IDM_VS_TOOL_MAINMENU` | 0x0000 | Main menu bar |
+| `IDM_VS_TOOL_STANDARD` | 0x0001 | Standard toolbar |
+| `IDM_VS_TOOL_WINDOWUI` | 0x0002 | Window UI toolbar |
+| `IDM_VS_TOOL_PROJWIN` | 0x0003 | Solution Explorer toolbar |
+| `IDM_VS_TOOL_DEBUGGER` | 0x0006 | Debugger toolbar |
+| `IDM_VS_TOOL_BUILD` | 0x000D | Build toolbar |
+| `IDM_VS_TOOL_TEXTEDITOR` | 0x000E | Text Editor toolbar |
+
+### Tool Window Toolbars
+
+| ID | Hex | Description |
+|----|-----|-------------|
+| `IDM_VS_TOOL_OBJBROWSER` | 0x000F | Object Browser toolbar |
+| `IDM_VS_TOOL_CLASSVIEW` | 0x0010 | Class View toolbar |
+| `IDM_VS_TOOL_PROPERTIES` | 0x0011 | Properties toolbar |
+| `IDM_VS_TOOL_DATA` | 0x0012 | Data toolbar |
+| `IDM_VS_TOOL_SCHEMA` | 0x0013 | Schema toolbar |
+| `IDM_VS_TOOL_OUTPUTWINDOW` | 0x0014 | Output Window toolbar |
+| `IDM_VS_TOOL_FINDRESULTS1` | 0x0015 | Find Results 1 toolbar |
+| `IDM_VS_TOOL_FINDRESULTS2` | 0x0016 | Find Results 2 toolbar |
+| `IDM_VS_TOOL_UNIFIEDFIND` | 0x0017 | Unified Find toolbar |
+| `IDM_VS_TOOL_FINDRESULTSTABLE` | 0x0018 | Find Results Table toolbar |
+| `IDM_VS_TOOL_BOOKMARKWIND` | 0x0019 | Bookmark Window toolbar |
+| `IDM_VS_TOOL_TASKLIST` | 0x002A | Task List toolbar |
+| `IDM_VS_TOOL_USERTASKS` | 0x002B | User Tasks toolbar |
+| `IDM_VS_TOOL_ERRORLIST` | 0x002C | Error List toolbar |
+| `IDM_VS_TOOL_SNIPPETMENUS` | 0x002D | Snippet menus |
+| `IDM_VS_TOOL_OBJECT_BROWSER_GO` | 0x0007 | Object Browser Go |
+| `IDM_VS_TOOL_CLASSVIEW_GO` | 0x0008 | Class View Go |
+| `IDM_VS_TOOL_OBJSEARCH` | 0x0009 | Object Search toolbar |
+| `IDM_VS_TOOL_FINDALLREF` | 0x000A | Find All References toolbar |
+| `IDM_VS_TOOL_OPENWINDOWS` | 0x000B | Open Windows toolbar |
+| `IDM_VS_TOOL_VIEWBAR` | 0x000C | View Bar toolbar |
+
+### Call Browser Toolbars
+
+| ID | Hex | Description |
+|----|-----|-------------|
+| `IDM_VS_TOOL_CALLBROWSER1` | 0x001A | Call Browser 1 |
+| `IDM_VS_TOOL_CALLBROWSER2` - `IDM_VS_TOOL_CALLBROWSER16` | 0x001B-0x0029 | Call Browser 2-16 |
+
+### Standard Toolbar Groups
+
+| ID | Hex | Description |
+|----|-----|-------------|
+| `IDG_VS_TOOLSB_NEWADD` | 0x0170 | New/Add |
+| `IDG_VS_TOOLSB_SAVEOPEN` | 0x0171 | Save/Open |
+| `IDG_VS_TOOLSB_CUTCOPY` | 0x0172 | Cut/Copy |
+| `IDG_VS_TOOLSB_UNDOREDO` | 0x0173 | Undo/Redo |
+| `IDG_VS_TOOLSB_RUNBUILD` | 0x0174 | Run/Build |
+| `IDG_VS_TOOLSB_GAUGE` | 0x0176 | Gauge |
+| `IDG_VS_TOOLSB_SEARCH` | 0x0177 | Search |
+| `IDG_VS_TOOLSB_NEWWINDOWS` | 0x0178 | New Windows |
+| `IDG_VS_TOOLSB_NAVIGATE` | 0x0179 | Navigate |
+
+---
+
+## Editor Menus and Groups
+
+### Editor Submenus
+
+| ID | Hex | Description |
+|----|-----|-------------|
+| `IDM_VS_EDITOR_BOOKMARK_MENU` | 0x3E9E | Bookmarks submenu |
+| `IDM_VS_EDITOR_ADVANCED_MENU` | 0x3EA0 | Advanced submenu |
+| `IDM_VS_EDITOR_OUTLINING_MENU` | 0x3EA1 | Outlining submenu |
+| `IDM_VS_EDITOR_INTELLISENSE_MENU` | 0x3EA2 | IntelliSense submenu |
+| `IDM_VS_EDITOR_FIND_MENU` | 0x3EA3 | Find submenu |
+| `IDM_VS_EDITOR_PASTE_MENU` | 0x3EA4 | Paste submenu |
+| `IDM_VS_EDITOR_GOTO_MENU` | 0x3EA5 | Go To submenu |
+| `IDM_VS_CODEWIN_SNIPPET_ROOT` | 0x02D3 | Snippets root |
+| `IDM_VS_CODEWIN_ANNOTATION_ROOT` | 0x02D6 | Annotations root |
+
+### Editor Groups
+
+| ID | Hex | Description |
+|----|-----|-------------|
+| `IDG_VS_EDITOR_CMDS` | 0x3E8A | Editor commands |
+| `IDG_VS_EDITOR_ADVANCED_CMDS` | 0x3E8F | Advanced commands |
+| `IDG_VS_EDITOR_OUTLINING_CMDS` | 0x3E90 | Outlining commands |
+| `IDG_VS_EDITOR_LANGUAGE_INFO` | 0x3E93 | Language info |
+| `IDG_VS_EDITOR_INTELLISENSE_CMDS` | 0x3E94 | IntelliSense commands |
+| `IDG_VS_EDITOR_BOOKMARK_FOLDER_CMDS` | 0x3EB0 | Bookmark folder commands |
+| `IDG_VS_EDITOR_BOOKMARK_DOCUMENT_CMDS` | 0x3EB1 | Bookmark document commands |
+| `IDG_VS_EDITOR_BOOKMARK_ALLDOCS_CMDS` | 0x3EB2 | Bookmark all docs commands |
+| `IDG_VS_EDITOR_BOOKMARK_TASKLIST_CMDS` | 0x3EB3 | Bookmark tasklist commands |
+
+---
+
+## Code Window Groups
+
+| ID | Hex | Description |
+|----|-----|-------------|
+| `IDG_VS_CODEWIN_TEXTEDIT` | 0x01C0 | Text editing |
+| `IDG_VS_CODEWIN_DEBUG_WATCH` | 0x01C2 | Debug watch |
+| `IDG_VS_CODEWIN_DEBUG_STEP` | 0x01C3 | Debug step |
+| `IDG_VS_CODEWIN_MARKER` | 0x01C4 | Markers |
+| `IDG_VS_CODEWIN_OPENURL` | 0x01C5 | Open URL |
+| `IDG_VS_CODEWIN_SHORTCUT` | 0x01C6 | Shortcuts |
+| `IDG_VS_CODEWIN_INTELLISENSE` | 0x02B0 | IntelliSense |
+| `IDG_VS_CODEWIN_NAVIGATETOLOCATION` | 0x02B1 | Navigate to location |
+| `IDG_VS_CODEWIN_NAVIGATETOFILE` | 0x02B2 | Navigate to file |
+| `IDG_VS_CODEWIN_OUTLINING` | 0x02B3 | Outlining |
+| `IDG_VS_CODEWIN_CTXT_OUTLINING` | 0x02B4 | Context outlining |
+| `IDG_VS_CODEWIN_REFACTORING` | 0x02B5 | Refactoring |
+| `IDG_VS_CODEWIN_LANGUAGE` | 0x02D0 | Language |
+| `IDG_VS_CODEWIN_ADVANCED` | 0x02D1 | Advanced |
+| `IDG_VS_CODEWIN_SNIPPETS` | 0x02D2 | Snippets |
+
+---
+
+## Cascade (Flyout) Menus
+
+| ID | Hex | Description |
+|----|-----|-------------|
+| `IDM_VS_CSCD_WINDOWS` | 0x0300 | Windows cascade |
+| `IDM_VS_CSCD_TASKLIST_SORT` | 0x0301 | Task List sort |
+| `IDM_VS_CSCD_TASKLIST_FILTER` | 0x0302 | Task List filter |
+| `IDM_VS_CSCD_TASKLIST_VIEWMENU_FILTER` | 0x0303 | Task List view filter |
+| `IDM_VS_CSCD_DEBUGWINDOWS` | 0x0304 | Debug windows cascade |
+| `IDM_VS_EDITOR_CSCD_OUTLINING_MENU` | 0x0305 | Editor outlining cascade |
+| `IDM_VS_CSCD_COMMANDBARS` | 0x0306 | Command bars cascade |
+| `IDM_VS_CSCD_OLEVERBS` | 0x0307 | OLE verbs cascade |
+| `IDM_VS_CSCD_NEW` | 0x0308 | New cascade |
+| `IDM_VS_CSCD_OPEN` | 0x0309 | Open cascade |
+| `IDM_VS_CSCD_ADD` | 0x030A | Add cascade |
+| `IDM_VS_CSCD_MNUDES` | 0x030B | Menu designer cascade |
+| `IDM_VS_CSCD_FILEMRU` | 0x030C | File MRU cascade |
+| `IDM_VS_CSCD_PROJMRU` | 0x030D | Project MRU cascade |
+| `IDM_VS_CSCD_NEW_PROJ` | 0x030E | New Project cascade |
+| `IDM_VS_CSCD_MOVETOPRJ` | 0x030F | Move to Project cascade |
+| `IDM_VS_CSCD_INTERACTIVEWNDWS` | 0x0310 | Interactive windows cascade |
+| `IDM_VS_CSCD_BUILD` | 0x0330 | Build cascade |
+| `IDM_VS_CSCD_REBUILD` | 0x0331 | Rebuild cascade |
+| `IDM_VS_CSCD_CLEAN` | 0x0332 | Clean cascade |
+| `IDM_VS_CSCD_DEPLOY` | 0x0333 | Deploy cascade |
+| `IDM_VS_CSCD_MISCFILES` | 0x0334 | Misc files cascade |
+| `IDM_VS_CSCD_PROJONLY` | 0x0335 | Project only cascade |
+| `IDM_VS_CSCD_PGO_BUILD` | 0x0336 | PGO build cascade |
+| `IDM_VS_CSCD_EXTTOOLS` | 0x0340 | External tools cascade |
+| `IDM_VS_CSCD_SOLUTION_ADD` | 0x0350 | Solution add cascade |
+| `IDM_VS_CSCD_SOLUTION_DEBUG` | 0x0351 | Solution debug cascade |
+| `IDM_VS_CSCD_PROJECT_ADD` | 0x0352 | Project add cascade |
+| `IDM_VS_CSCD_PROJECT_DEBUG` | 0x0353 | Project debug cascade |
+| `IDM_VS_CSCD_CV_PROJADD` | 0x0354 | Class View project add |
+| `IDM_VS_CSCD_CV_ITEMADD` | 0x0355 | Class View item add |
+| `IDM_VS_CSCD_SLNFLDR_ADD` | 0x0357 | Solution folder add |
+| `IDM_VS_CSCD_TASKLIST_COLUMNS` | 0x0358 | Task List columns |
+| `IDM_VS_CSCD_CALLBROWSER` | 0x0359 | Call Browser cascade |
+| `IDM_VS_CSCD_FINDRESULTS` | 0x035D | Find Results cascade |
+| `IDM_VS_CSCD_PROJECT_ANALYZE` | 0x035E | Project analyze |
+| `IDM_VS_CSCD_PROJECT_CONVERT` | 0x0360 | Project convert |
+| `IDM_VS_CSCD_PROJECT_BUILDDEPENDENCIES` | 0x0361 | Build dependencies |
+| `IDM_VS_CSCD_PROJECT_SCC` | 0x0362 | Source control |
+| `IDM_VS_CSCD_WINDOW_LAYOUTS` | 0x0363 | Window layouts |
+| `IDM_VS_CSCD_TASKLIST_GROUPS` | 0x0364 | Task List groups |
+| `IDM_VS_CSCD_ITEM_ANALYZE` | 0x036A | Item analyze |
+
+---
+
+## Context Menus
+
+### Solution Explorer
+
+| ID | Hex | Description |
+|----|-----|-------------|
+| `IDM_VS_CTXT_SOLNNODE` | 0x0413 | Solution node |
+| `IDM_VS_CTXT_SOLNFOLDER` | 0x0414 | Solution folder |
+| `IDM_VS_CTXT_PROJNODE` | 0x0402 | Project node |
+| `IDM_VS_CTXT_PROJWIN` | 0x0403 | Project window |
+| `IDM_VS_CTXT_ITEMNODE` | 0x0430 | File/item node |
+| `IDM_VS_CTXT_FOLDERNODE` | 0x0431 | Folder node |
+| `IDM_VS_CTXT_STUBPROJECT` | 0x0412 | Unloaded project |
+| `IDM_VS_CTXT_MISCFILESPROJ` | 0x041B | Miscellaneous Files |
+| `IDM_VS_CTXT_NOCOMMANDS` | 0x041A | No selection |
+| `IDM_VS_CTXT_APPDESIGNERFOLDER` | 0x0453 | App Designer folder |
+| `IDM_VS_CTXT_PROJWIN_FILECONTENTS` | 0x0732 | File contents |
+| `IDM_VS_CTXT_SOLNEXPL_ALL` | 0x0495 | All Solution Explorer |
+
+### References
+
+| ID | Hex | Description |
+|----|-----|-------------|
+| `IDM_VS_CTXT_REFERENCEROOT` | 0x0450 | References folder |
+| `IDM_VS_CTXT_REFERENCE` | 0x0451 | Reference item |
+| `IDM_VS_CTXT_WEBREFFOLDER` | 0x0452 | Web References folder |
+| `IDM_VS_CTXT_REFERENCE_GROUP` | 0x04A1 | Assembly references |
+| `IDM_VS_CTXT_PACKAGEREFERENCE_GROUP` | 0x04A2 | Package references |
+| `IDM_VS_CTXT_PACKAGEREFERENCE` | 0x04A3 | Package reference |
+| `IDM_VS_CTXT_COMREFERENCE_GROUP` | 0x04A4 | COM references |
+| `IDM_VS_CTXT_COMREFERENCE` | 0x04A5 | COM reference |
+| `IDM_VS_CTXT_PROJECTREFERENCE_GROUP` | 0x04A6 | Project references |
+| `IDM_VS_CTXT_PROJECTREFERENCE` | 0x04A7 | Project reference |
+| `IDM_VS_CTXT_SHAREDPROJECTREFERENCE` | 0x04A8 | Shared project reference |
+| `IDM_VS_CTXT_FRAMEWORKREFERENCE_GROUP` | 0x04A9 | Framework references |
+| `IDM_VS_CTXT_FRAMEWORKREFERENCE` | 0x04AA | Framework reference |
+| `IDM_VS_CTXT_ANALYZERREFERENCE_GROUP` | 0x04AB | Analyzer references |
+| `IDM_VS_CTXT_ANALYZERREFERENCE` | 0x04AC | Analyzer reference |
+| `IDM_VS_CTXT_SDKREFERENCE_GROUP` | 0x04AD | SDK references |
+| `IDM_VS_CTXT_SDKREFERENCE` | 0x04AE | SDK reference |
+| `IDM_VS_CTXT_DEPENDENCYTARGET` | 0x04A0 | Target framework |
+| `IDM_VS_CTXT_DEPENDENCY_TRANSITIVE_ITEM` | 0x04B0 | Transitive item |
+| `IDM_VS_CTXT_TRANSITIVE_ASSEMBLY_REFERENCE` | 0x04B1 | Transitive assembly |
+| `IDM_VS_CTXT_TRANSITIVE_PACKAGE_REFERENCE` | 0x04B2 | Transitive package |
+| `IDM_VS_CTXT_TRANSITIVE_PROJECT_REFERENCE` | 0x04B3 | Transitive project |
+
+### Multi-Selection
+
+| ID | Hex | Description |
+|----|-----|-------------|
+| `IDM_VS_CTXT_XPROJ_SLNPROJ` | 0x0415 | Solution + project |
+| `IDM_VS_CTXT_XPROJ_SLNITEM` | 0x0416 | Solution + item |
+| `IDM_VS_CTXT_XPROJ_PROJITEM` | 0x0417 | Project + item |
+| `IDM_VS_CTXT_XPROJ_MULTIPROJ` | 0x0418 | Multiple projects |
+| `IDM_VS_CTXT_XPROJ_MULTIITEM` | 0x0419 | Multiple items |
+| `IDM_VS_CTXT_XPROJ_MULTIFOLDER` | 0x041C | Multiple folders |
+| `IDM_VS_CTXT_XPROJ_MULTIPROJFLDR` | 0x041D | Multiple projects/folders |
+
+### Code Editor
+
+| ID | Hex | Description |
+|----|-----|-------------|
+| `IDM_VS_CTXT_CODEWIN` | 0x040D | Code window |
+| `IDM_VS_CTXT_EDITOR_ALL` | 0x0498 | All editor contexts |
+| `IDM_VS_CTXT_ERROR_CORRECTION` | 0x0480 | Error correction |
+| `IDM_VS_CTX_REFACTORING` | 0x0497 | Refactoring |
+
+### Class View
+
+| ID | Hex | Description |
+|----|-----|-------------|
+| `IDM_VS_CTXT_CV_PROJECT` | 0x0432 | Class View project |
+| `IDM_VS_CTXT_CV_ITEM` | 0x0433 | Class View item |
+| `IDM_VS_CTXT_CV_FOLDER` | 0x0434 | Class View folder |
+| `IDM_VS_CTXT_CV_GROUPINGFOLDER` | 0x0435 | Grouping folder |
+| `IDM_VS_CTXT_CV_MEMBER` | 0x0438 | Member |
+| `IDM_VS_CTXT_CV_MULTIPLE` | 0x0436 | Multiple selection |
+| `IDM_VS_CTXT_CV_MULTIPLE_MEMBERS` | 0x0437 | Multiple members |
+| `IDM_VS_CTXT_CV_NON_SYMBOL_MEMBERS` | 0x0439 | Non-symbol members |
+| `IDM_VS_CTXT_CV_PROJECT_REFS_FOLDER` | 0x0440 | References folder |
+| `IDM_VS_CTXT_CV_PROJECT_REFERENCE` | 0x0441 | Reference |
+| `IDM_VS_CTXT_CV_NO_SOURCE_ITEM` | 0x0442 | Item without source |
+| `IDM_VS_CTXT_CV_NO_SOURCE_MEMBER` | 0x0443 | Member without source |
+| `IDM_VS_CTXT_CV_ALL` | 0x0491 | All Class View |
+
+### Object Browser
+
+| ID | Hex | Description |
+|----|-----|-------------|
+| `IDM_VS_CTXT_OBJBROWSER_OBJECTS` | 0x0445 | Objects pane |
+| `IDM_VS_CTXT_OBJBROWSER_MEMBERS` | 0x0446 | Members pane |
+| `IDM_VS_CTXT_OBJBROWSER_DESC` | 0x0447 | Description pane |
+| `IDM_VS_CTXT_OBJSEARCH` | 0x0448 | Object search |
+| `IDM_VS_CTXT_OBJBROWSER_ALL` | 0x0493 | All Object Browser |
+
+### Tool Windows
+
+| ID | Hex | Description |
+|----|-----|-------------|
+| `IDM_VS_CTXT_ERRORLIST` | 0x0405 | Error List |
+| `IDM_VS_CTXT_TASKLIST` | 0x040E | Task List |
+| `IDM_VS_CTXT_RESULTSLIST` | 0x0411 | Find Results |
+| `IDM_VS_CTXT_FINDALLREF` | 0x0454 | Find All References |
+| `IDM_VS_CTXT_COMMANDWINDOW` | 0x041F | Command Window |
+| `IDM_VS_CTXT_PROPBRS` | 0x0408 | Properties window |
+| `IDM_VS_CTXT_TOOLBOX` | 0x0409 | Toolbox |
+| `IDM_VS_CTXT_BOOKMARK` | 0x0473 | Bookmarks |
+| `IDM_VS_CTXT_CALLBROWSER` | 0x0663 | Call Browser |
+| `IDM_VS_CTXT_PREVIEWCHANGES` | 0x06D1 | Preview Changes |
+| `IDM_VS_CTXT_PEEKRESULT` | 0x0739 | Peek results |
+
+### Window Management
+
+| ID | Hex | Description |
+|----|-----|-------------|
+| `IDM_VS_CTXT_DOCKEDWINDOW` | 0x0406 | Docked window |
+| `IDM_VS_CTXT_AUTOHIDE` | 0x0420 | Auto-hide |
+| `IDM_VS_CTXT_EZTOOLWINTAB` | 0x042A | Tool window tab |
+| `IDM_VS_CTXT_EZDOCWINTAB` | 0x042B | Document tab |
+| `IDM_VS_CTXT_EZDRAGGING` | 0x042C | Dragging |
+| `IDM_VS_CTXT_EZCHANNEL` | 0x042D | Auto-hide channel |
+| `IDM_VS_CTXT_DOCUMENT_TABWELL` | 0x0740 | Document tab well |
+| `IDM_VS_CTXT_FLOATING_DOCUMENT_TABWELL` | 0x0741 | Floating tab well |
+| `IDM_VS_CTXT_DOCUMENT_TABWELL_SETTINGS` | 0x0745 | Tab well settings |
+| `IDM_VS_CTXT_TOOLBARS` | 0x4805 | Toolbar area |
+
+### Web Projects
+
+| ID | Hex | Description |
+|----|-----|-------------|
+| `IDM_VS_CTXT_WEBPROJECT` | 0x0470 | Web project |
+| `IDM_VS_CTXT_WEBFOLDER` | 0x0471 | Web folder |
+| `IDM_VS_CTXT_WEBITEMNODE` | 0x0472 | Web item |
+| `IDM_VS_CTXT_WEBSUBWEBNODE` | 0x0474 | Sub-web node |
+
+### Miscellaneous Context Menus
+
+| ID | Hex | Description |
+|----|-----|-------------|
+| `IDM_VS_CTXT_MISC` | 0x0490 | Miscellaneous |
+| `IDM_VS_CTXT_RIGHT_DRAG` | 0x0460 | Right-drag |
+| `IDM_VS_CTXT_PROJWINBREAK` | 0x0404 | Project window break |
+| `IDM_VS_CTXT_EXPANSION_DESC` | 0x0421 | Expansion description |
+| `IDM_VS_CTXT_FIND_REGEX` | 0x0424 | Find regex |
+| `IDM_VS_CTXT_REPLACE_REGEX` | 0x0425 | Replace regex |
+| `IDM_VS_CTXT_FIND_WILD` | 0x0426 | Find wildcards |
+| `IDM_VS_CTXT_REPLACE_WILD` | 0x0427 | Replace wildcards |
+| `IDM_VS_CTXT_EXTTOOLSARGS` | 0x0428 | External tools args |
+| `IDM_VS_CTXT_EXTTOOLSDIRS` | 0x0429 | External tools dirs |
+| `IDM_VS_CTXT_OPENDROPDOWN` | 0x042E | Open dropdown |
+| `IDM_VS_CTXT_FRAMEWORKVERSION` | 0x042F | Framework version |
+| `IDM_VS_CTXT_MENUDES` | 0x0407 | Menu designer |
+
+---
+
+## Solution Explorer Context Menu Groups
+
+| ID | Hex | Description |
+|----|-----|-------------|
+| `IDG_VS_CTXT_SOLUTION_BUILD` | — | Solution build group |
+| `IDG_VS_CTXT_PROJECT_BUILD` | — | Project build group |
+| `IDG_VS_CTXT_FOLDER_ADD` | — | Folder add group |
+| `IDG_VS_CTXT_ITEM_OPEN` | — | Item open group |
+| `IDG_VS_CTXT_REFROOT_ADD` | — | Reference root add group |
+| `IDG_VS_CTXT_REFERENCE` | — | Reference group |
+| `IDG_VS_MISCFILES_PROJ` | 0x01B8 | Misc files project |
+| `IDG_VS_MISCFILES_PROJITEM` | 0x01BA | Misc files project item |
+| `IDG_VS_SOLNITEMS_PROJ` | 0x01BC | Solution items project |
+| `IDG_VS_SOLNITEMS_PROJITEM` | 0x01BD | Solution items project item |
+| `IDG_VS_STUB_PROJECT` | 0x01BE | Stub project |
+
+---
+
+## Special Menus
+
+| ID | Hex | Description |
+|----|-----|-------------|
+| `IDM_VS_TOOL_UNDEFINED` | 0xEDFF | Undefined toolbar |
+| `IDM_VS_TOOL_ADDCOMMAND` | 0xEE00 | Add command |
+| `IDM_VS_CALLBROWSER_TYPE_POPUP` | 0x0030 | Call Browser type popup |
+| `IDM_VS_SYMBOLS_DUMMY` | 0x0444 | Symbols dummy |
+| `IDM_VS_DOCUMENT_DUPLICATE` | 0x0400 | Document duplicate |
+| `IDM_VS_EZ_TABCOLOR` | 0x0401 | Tab color |
+| `IDM_VS_WINDOW_MOVE` | 0x040A | Window move |
+| `IDM_VS_DOCUMENT_MOVE` | 0x040B | Document move |
+
+---
+
+## Menu Controller IDs
+
+| ID | Hex | Description |
+|----|-----|-------------|
+| `IDM_VS_MNUCTRL_NEWITM` | 0x0500 | New item controller |
+| `IDM_VS_MNUCTRL_NEWPRJ` | 0x0501 | New project controller |
+| `IDM_VS_MNUCTRL_OPENPRJ` | 0x051F | Open project controller |
+| `IDM_VS_MNUCTRL_OTRWNDWS` | 0x0502 | Other windows controller |
+| `IDM_VS_MNUCTRL_NAVBACK` | 0x0503 | Navigate back controller |
+| `IDM_VS_MNUCTRL_OBSEARCHOPTS` | 0x0504 | OB search options |
+| `IDM_VS_MNUCTRL_CVGROUPING` | 0x0505 | CV grouping |
+| `IDM_VS_MNUCTRL_OBGRPOBJS` | 0x0506 | OB group objects |
+| `IDM_VS_MNUCTRL_OBGRPMEMS` | 0x0507 | OB group members |
+| `IDM_VS_MNUCTRL_OBGRPVIEWS` | 0x0509 | OB group views |
+| `IDM_VS_MNUCTRL_OBGRPMEMSACCESS` | 0x050A | OB group members access |
+| `IDM_VS_MNUCTRL_FIND` | 0x051B | Find controller |
+| `IDM_VS_MNUCTRL_REPLACE` | 0x051C | Replace controller |
+| `IDM_VS_MNUCTRL_FILTERERRORLIST` | 0x051D | Error List filter |
+| `IDM_VS_MNUCTRL_FILTERSOLUTIONEXPLORER` | 0x051E | Solution Explorer filter |
+
+---
+
+## See Also
+
+- [Context Menus](context-menus) - How to add commands to context menus
+- [Commands](commands) - Command and VSCT basics
+- [Tool Window GUIDs](tool-window-guids) - Tool window identifiers


### PR DESCRIPTION
## Summary
Add a complete reference of ALL Visual Studio menu and command group identifiers from the VS SDK.

## Contents (~600 lines)

### Main Menu Bar
- Top-level menus (File, Edit, View, Project, Build, Debug, Format, Tools, Extensions, Window, Help)
- Main menu groups (`IDG_VS_MM_*`)

### Menu Groups by Category
- File menu groups (New, Open, Save, MRU, etc.)
- Edit menu groups (Undo, Cut/Copy, Find, Go To)
- View menu groups (Windows, Navigate, Toolbars)
- Project menu groups (Add, References, Settings)
- Debug menu groups (Start, Step, Watch, Breakpoints)
- Tools menu groups (Options, External Tools, Extensions)
- Window menu groups (Layout, Navigation)
- Help menu groups

### Toolbars
- Standard toolbars (Main, Standard, Debugger, Build, etc.)
- Tool window toolbars (Solution Explorer, Error List, Output, Find Results, etc.)
- Toolbar groups

### Editor Menus and Groups
- Editor submenus (Bookmarks, Advanced, Outlining, IntelliSense)
- Code window groups

### Cascade/Flyout Menus
- All `IDM_VS_CSCD_*` menus

### Context Menus (Complete!)
- Solution Explorer (solution, project, folder, item)
- References (all types: package, COM, project, framework, analyzer, SDK, transitive)
- Multi-selection contexts
- Code editor
- Class View (all node types)
- Object Browser
- All tool windows
- Window management (tabs, docking, auto-hide)
- Web projects
- Miscellaneous

### Special
- Menu controller IDs
- Special menus

## Source
All IDs extracted from `vsshlids.h` in the VS SDK.

## Test plan
- [ ] Verify the page renders correctly
- [ ] Verify the page appears in the Reference section of the sidebar
- [ ] Verify tables are properly formatted